### PR TITLE
Add gatsby-remark-external-links to handle markdown links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -38,6 +38,13 @@ module.exports = {
       options: {
         plugins: [
           {
+            resolve: `gatsby-remark-external-links`,
+            options: {
+              target: `_blank`,
+              rel: `nofollow noopener noreferrer`
+            }
+          },
+          {
             resolve: 'gatsby-remark-embed-soundcloud',
             options: {
               width: '100%',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9757,6 +9757,17 @@
         "unist-util-visit": "^1.1.3"
       }
     },
+    "gatsby-remark-external-links": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz",
+      "integrity": "sha512-JIKZguAGoGlzsJusfCb4JKM5E6JUEDbtlBkbErt7CdMnfBP+AldZeMQEQWK5xsJ5uXCyc4qqcBWR8vp0afFpOw==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "is-relative-url": "^2.0.0",
+        "unist-util-find": "^1.0.1",
+        "unist-util-visit": "^1.1.3"
+      }
+    },
     "gatsby-remark-images": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.20.tgz",
@@ -12900,6 +12911,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.iteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
+      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -21037,6 +21053,87 @@
       "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
       "requires": {
         "object-assign": "^4.1.0"
+      }
+    },
+    "unist-util-find": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.1.tgz",
+      "integrity": "sha1-EGK7tpKMepfGrcibU3RdTEbCIqI=",
+      "requires": {
+        "lodash.iteratee": "^4.5.0",
+        "remark": "^5.0.1",
+        "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "longest-streak": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+          "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
+        },
+        "markdown-table": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+          "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
+        },
+        "remark": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz",
+          "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
+          "requires": {
+            "remark-parse": "^1.1.0",
+            "remark-stringify": "^1.1.0",
+            "unified": "^4.1.1"
+          }
+        },
+        "remark-parse": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz",
+          "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "extend": "^3.0.0",
+            "parse-entities": "^1.0.2",
+            "repeat-string": "^1.5.4",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0"
+          }
+        },
+        "remark-stringify": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz",
+          "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
+          "requires": {
+            "ccount": "^1.0.0",
+            "extend": "^3.0.0",
+            "longest-streak": "^1.0.0",
+            "markdown-table": "^0.4.0",
+            "parse-entities": "^1.0.2",
+            "repeat-string": "^1.5.4",
+            "stringify-entities": "^1.0.1",
+            "unherit": "^1.0.4"
+          }
+        },
+        "unified": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz",
+          "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "has": "^1.0.1",
+            "once": "^1.3.3",
+            "trough": "^1.0.0",
+            "vfile": "^1.0.0"
+          }
+        },
+        "vfile": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+          "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
+        }
       }
     },
     "unist-util-generated": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-remark-copy-linked-files": "^2.0.7",
     "gatsby-remark-embed-soundcloud": "^1.0.0",
+    "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-images": "^3.1.6",
     "gatsby-remark-relative-images": "^0.2.1",
     "gatsby-source-filesystem": "^2.0.26",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the gatsby-remark-external-links plugin to handle external links in markdown files
<!--- Describe your changes in detail -->

## Motivation and Context
This solves the problem of links redirecting to the homepage instead of to external sites
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
