### PR TITLE
Feature: Podcast page shows podcasts with embedded players

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,7 +48,7 @@ module.exports = {
             resolve: 'gatsby-remark-embed-soundcloud',
             options: {
               width: '100%',
-              height: 300,
+              height: '100%',
               color: 'FF4400',
               autoplay: false
             }

--- a/src/img/calendar-icon.svg
+++ b/src/img/calendar-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21">
+  <text fill="#9B9B9B" fill-rule="evenodd" font-family="simple-line-icons" font-size="20" transform="translate(0 -1)">
+    <tspan x="0" y="20"></tspan>
+  </text>
+</svg>

--- a/src/img/clock-icon.svg
+++ b/src/img/clock-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21">
+  <text fill="#9B9B9B" fill-rule="evenodd" font-family="simple-line-icons" font-size="20">
+    <tspan x="0" y="19"></tspan>
+  </text>
+</svg>

--- a/src/pages/podcast/2019-09-11-lonestar-adventurecast-004.md
+++ b/src/pages/podcast/2019-09-11-lonestar-adventurecast-004.md
@@ -5,6 +5,8 @@ date: 2019-09-11T22:12:00.000Z
 description: >-
   We are back with another cast featuring local musician and laugh doctor,
   Shular Roberts. And your host/co-host, Christopher Colon and Roscoe Bertsch.
+runtime: >-
+  30:34
 featuredpost: true
 featuredimage: /img/img_1573.jpg
 tags:

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -1,38 +1,115 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 
 import Layout from '../../components/Layout'
 import PodcastRoll from '../../components/PodcastRoll'
+import Soundcloud from '../../components/Soundcloud'
+import calendar from '../../img/calendar-icon.svg'
+import clock from '../../img/clock-icon.svg'
 
-export default class PodcastIndexPage extends React.Component {
-  render() {
-    return (
-      <Layout>
-        <div
-          className='full-width-image-container margin-top-0'
+const PodcastIndexPage = ({ data }) => {
+  const { edges: podcasts } = data.allMarkdownRemark
+  return (
+    <Layout>
+      <div
+        className='full-width-image-container margin-top-0'
+        style={{
+          backgroundImage: `url('/img/img_1102.jpg')`
+        }}
+      >
+        <h1
+          className='has-text-weight-bold is-size-1'
           style={{
-            backgroundImage: `url('/img/img_1102.jpg')`
+            boxShadow: '0.5rem 0 0 #f40, -0.5rem 0 0 #f40',
+            backgroundColor: '#f40',
+            color: 'white',
+            padding: '1rem'
           }}
         >
-          <h1
-            className='has-text-weight-bold is-size-1'
-            style={{
-              boxShadow: '0.5rem 0 0 #f40, -0.5rem 0 0 #f40',
-              backgroundColor: '#f40',
-              color: 'white',
-              padding: '1rem'
-            }}
-          >
-            Latest Podcasts
-          </h1>
-        </div>
-        <section className='section'>
-          <div className='container'>
-            <div className='content'>
-              <PodcastRoll />
+          Latest Podcasts
+        </h1>
+      </div>
+      <section className='section'>
+        <div className='container'>
+          <div className='content'>
+            {/* <PodcastRoll /> */}
+            <div className='columns'>
+              {podcasts &&
+                podcasts.map(({ node: post }) => (
+                  <div className='column is-10 is-offset-1 box' key={post.id}>
+                    <div className='columns'>
+                      <div className='column is-4'>
+                        <Soundcloud html={post.htmlAst} />
+                      </div>
+                      <div className='column'>
+                        <h3>{post.frontmatter.title}</h3>
+                        <p
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            color: '#9B9B9B',
+                            fontSize: '15px'
+                          }}
+                        >
+                          <img
+                            src={calendar}
+                            alt='calendar'
+                            style={{
+                              width: '15px',
+                              marginRight: '6px',
+                              marginLeft: '10px'
+                            }}
+                          />
+                          {post.frontmatter.date}
+                          <img
+                            src={clock}
+                            alt='clock'
+                            style={{
+                              width: '15px',
+                              marginRight: '6px',
+                              marginLeft: '20px'
+                            }}
+                          />
+                          {post.frontmatter.runtime}
+                        </p>
+                        <p>{post.frontmatter.description}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
             </div>
           </div>
-        </section>
-      </Layout>
-    )
-  }
+        </div>
+      </section>
+    </Layout>
+  )
 }
+
+export const query = graphql`
+  query PodcastList {
+    allMarkdownRemark(
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: { frontmatter: { templateKey: { eq: "podcast-post" } } }
+    ) {
+      edges {
+        node {
+          htmlAst
+          id
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            templateKey
+            runtime
+            date(formatString: "MMMM Do, YYYY")
+            featuredpost
+            description
+          }
+        }
+      }
+    }
+  }
+`
+
+export default PodcastIndexPage

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -31,6 +31,7 @@ collections:
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Description", name: "description", widget: "text"}
+      - {label: "Runtime", name: "runtime", widget: "text", hint: "ex: 4:25 for Four minutes and 25 seconds"}
       - {label: "Featured Post", name: "featuredpost", widget: "boolean"}
       - {label: "Featured Image", name: "featuredimage", widget: image}
       - {label: "Body", name: "body", widget: "markdown", hint: "Include soundcloud link anywhere you want it to appear embedded in post"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change shows a list of podcasts with the embedded player already loaded on the page.
Prior to the change, the cards were similar to blog posts, where you had to select one to be taken to an individual podcast page where you could listen to the actual podcast.
<!--- Describe your changes in detail -->

## Motivation and Context
The change was made so that podcast content is easier to browse and consume.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<img width="1280" alt="Screen Shot 2019-09-13 at 2 12 59 PM" src="https://user-images.githubusercontent.com/8987167/64895183-9e0df580-d630-11e9-99d6-bd0f6ac0e6ab.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
