### PR TITLE
Remove margin-right from footer column

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -20,7 +20,7 @@ const Footer = class extends React.Component {
         </div>
         <div className='content has-text-centered has-background-black has-text-white-ter'>
           <div className='container has-background-black has-text-white-ter'>
-            <div className='columns'>
+            <div className='columns' style={{ marginRight: '0' }}>
               <div className='column is-4'>
                 <section className='menu'>
                   <ul className='menu-list'>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed layout bug that was causing mobile to have extra whitespace to the side of the page.
Removed default margin from column class.
<!--- Describe your changes in detail -->

## Motivation and Context
Improves UX for mobile website.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<img width="377" alt="Screen Shot 2019-09-16 at 11 13 44 AM" src="https://user-images.githubusercontent.com/8987167/64982485-27ad0580-d873-11e9-93be-ccdaadfc4af4.png">
<img width="379" alt="Screen Shot 2019-09-16 at 11 14 13 AM" src="https://user-images.githubusercontent.com/8987167/64982491-2a0f5f80-d873-11e9-9744-01669a2345b6.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
